### PR TITLE
Refactor Packet definition

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/utils/src/main.rs
+++ b/utils/src/main.rs
@@ -1,0 +1,8 @@
+use packet::Packet;
+
+pub mod packet;
+
+fn main() {
+    let pkt: Packet = Packet::init();
+    println!("{}", pkt.get_pkt_type());
+}

--- a/utils/src/packet.rs
+++ b/utils/src/packet.rs
@@ -1,3 +1,5 @@
+use std::net::TcpStream;
+
 enum FlagState {
     WARNING,
     COLLISION,
@@ -5,6 +7,53 @@ enum FlagState {
     EXIT,
 }
 
-struct Packet {
-    flag: FlagState
+pub struct PacketHeader {
+    flag: FlagState,
+    plane_id: u8,
+    body_size: u8,
+}
+
+impl PacketHeader {
+    pub fn init() -> PacketHeader {
+        return PacketHeader {
+            flag: FlagState::COORDINATE,
+            plane_id: 0,
+            body_size: 0,
+        };
+    }
+    // Hypothetical data stream, could just be a buffer read and passed to this
+    fn read_packet_header(_stream: TcpStream) { // -> Self {
+        //Self {
+        //  self.flag = read(stream, 1)
+        //  self.plane_id = read(stream, 1)
+        //  self.body_size = read(stream, 1)
+        //}
+    }
+}
+
+pub struct Packet {
+    header: PacketHeader,
+    body: Vec<u8>,
+}
+
+impl Packet {
+    pub fn init() -> Packet {
+        return Packet {
+            header: PacketHeader::init(),
+            body: Vec::new(),
+        };
+    }
+    fn read_body(_stream: TcpStream) {
+        //self.body = read(stream, self.header.body_size)
+    }
+    pub fn get_pkt_type(&self) -> String {
+        let ret: &str;
+        match self.header.flag {
+            FlagState::COORDINATE => ret = "COORDINATE",
+            FlagState::EXIT => ret = "EXIT",
+            FlagState::WARNING => ret = "WARNING",
+            FlagState::COLLISION => ret = "COLLISION",
+        }
+        return String::from(ret);
+    }
 }

--- a/utils/src/packet.rs
+++ b/utils/src/packet.rs
@@ -1,6 +1,7 @@
+use std::fmt;
 use tokio::net::TcpStream;
 #[repr(u8)]
-enum FlagState {
+pub enum FlagState {
     WARNING = 0,
     COLLISION = 1,
     COORDINATE = 2,
@@ -8,7 +9,7 @@ enum FlagState {
 }
 
 impl FlagState {
-    fn init(in_state: u8) -> FlagState {
+    pub fn init(in_state: u8) -> FlagState {
         match in_state {
             0 => FlagState::WARNING,
             1 => FlagState::COLLISION,
@@ -23,9 +24,9 @@ impl FlagState {
 }
 
 pub struct PacketHeader {
-    flag: FlagState,
-    plane_id: u8,
-    body_size: u16,
+    pub flag: FlagState,
+    pub plane_id: u8,
+    pub body_size: u16,
 }
 
 impl PacketHeader {
@@ -46,8 +47,8 @@ impl PacketHeader {
 }
 
 pub struct Packet {
-    header: PacketHeader,
-    body: Vec<u8>,
+    pub header: PacketHeader,
+    pub body: Vec<u8>,
 }
 
 impl Packet {
@@ -57,15 +58,46 @@ impl Packet {
             body: Vec::new(),
         };
     }
-    pub fn get_pkt_type(&self) -> String {
+}
+
+impl fmt::Display for FlagState {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let ret: &str;
-        match self.header.flag {
+        match self {
             FlagState::COORDINATE => ret = "COORDINATE",
             FlagState::EXIT => ret = "EXIT",
             FlagState::WARNING => ret = "WARNING",
             FlagState::COLLISION => ret = "COLLISION",
         }
-        return String::from(ret);
+        // Write strictly the first element into the supplied output
+        // stream: `f`. Returns `fmt::Result` which indicates whether the
+        // operation succeeded or failed. Note that `write!` uses syntax which
+        // is very similar to `println!`.
+        write!(f, "{}", String::from(ret))
+    }
+}
+
+impl fmt::Display for PacketHeader {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "[{0}, {1}, {2}]",
+            self.flag, self.plane_id, self.body_size
+        )
+    }
+}
+
+impl fmt::Display for Packet {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{0}\n{1}",
+            self.header,
+            String::from_utf8(self.body.clone()).unwrap()
+        )
     }
 }
 

--- a/utils/src/packet.rs
+++ b/utils/src/packet.rs
@@ -112,12 +112,10 @@ impl fmt::Display for PacketHeader {
 impl fmt::Display for Packet {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{0}\n{1}",
-            self.header,
-            String::from_utf8(self.body.clone()).unwrap()
-        )
+        match String::from_utf8(self.body.clone()) {
+            Ok(body_string) => write!(f, "{0}\n{1}", self.header, body_string),
+            Err(_) => write!(f, "{}\n{:?}", self.header, self.body.as_slice()),
+        } 
     }
 }
 

--- a/utils/src/packet.rs
+++ b/utils/src/packet.rs
@@ -1,0 +1,10 @@
+enum FlagState {
+    WARNING,
+    COLLISION,
+    COORDINATE,
+    EXIT,
+}
+
+struct Packet {
+    flag: FlagState
+}

--- a/utils/src/packet.rs
+++ b/utils/src/packet.rs
@@ -1,16 +1,31 @@
-use std::net::TcpStream;
-
+use tokio::net::TcpStream;
+#[repr(u8)]
 enum FlagState {
-    WARNING,
-    COLLISION,
-    COORDINATE,
-    EXIT,
+    WARNING = 0,
+    COLLISION = 1,
+    COORDINATE = 2,
+    EXIT = 3,
+}
+
+impl FlagState {
+    fn init(in_state: u8) -> FlagState {
+        match in_state {
+            0 => FlagState::WARNING,
+            1 => FlagState::COLLISION,
+            2 => FlagState::COORDINATE,
+            3 => FlagState::EXIT,
+            4_u8..=u8::MAX => {
+                eprintln!("Invalid integer called for FlagState");
+                return FlagState::WARNING;
+            }
+        }
+    }
 }
 
 pub struct PacketHeader {
     flag: FlagState,
     plane_id: u8,
-    body_size: u8,
+    body_size: u16,
 }
 
 impl PacketHeader {
@@ -20,14 +35,6 @@ impl PacketHeader {
             plane_id: 0,
             body_size: 0,
         };
-    }
-    // Hypothetical data stream, could just be a buffer read and passed to this
-    fn read_packet_header(_stream: TcpStream) { // -> Self {
-        //Self {
-        //  self.flag = read(stream, 1)
-        //  self.plane_id = read(stream, 1)
-        //  self.body_size = read(stream, 1)
-        //}
     }
 }
 
@@ -43,9 +50,6 @@ impl Packet {
             body: Vec::new(),
         };
     }
-    fn read_body(_stream: TcpStream) {
-        //self.body = read(stream, self.header.body_size)
-    }
     pub fn get_pkt_type(&self) -> String {
         let ret: &str;
         match self.header.flag {
@@ -56,4 +60,42 @@ impl Packet {
         }
         return String::from(ret);
     }
+}
+
+// To use the vector return, just use &[variablename]
+pub fn serialize_packet(pkt: Packet) -> Vec<u8> {
+    let mut seralized_bytes: Vec<u8> = Vec::new();
+    seralized_bytes.push(pkt.header.flag as u8);
+    seralized_bytes.push(pkt.header.plane_id);
+    seralized_bytes.push(pkt.header.body_size.try_into().unwrap());
+    seralized_bytes.extend_from_slice(&pkt.body);
+    return seralized_bytes;
+}
+
+pub fn deserialize_stream(stream: TcpStream) -> Packet {
+    let mut rcv_buf_header: Vec<u8> = vec![0; std::mem::size_of::<PacketHeader>()];
+    let mut pkt: Packet = Packet::init();
+    let pkt_header = &mut pkt.header;
+
+    // Read the data from the buffer
+    if let Err(_e) = stream.try_read(&mut rcv_buf_header) {
+        //eprintln!("{}", e);
+        //return Err(e);
+    }
+
+    pkt_header.flag = FlagState::init(*rcv_buf_header.get(1).unwrap());
+    pkt_header.plane_id = *rcv_buf_header.get(2).unwrap();
+    pkt_header.body_size = u16::from_ne_bytes([
+        *rcv_buf_header.get(3).unwrap(),
+        *rcv_buf_header.get(4).unwrap(),
+    ]);
+
+    let mut rcv_buf: Vec<u8> = vec![0; pkt_header.body_size.into()];
+    if let Err(_e) = stream.try_read(&mut rcv_buf) {
+        //eprintln!("{}", e);
+        //return Err(e);
+    }
+    pkt.body = rcv_buf;
+
+    return pkt;
 }


### PR DESCRIPTION
### Changes made
- Redefine the Packet struct so that it fully fits our requirements.
- Create a PacketHeader to help understand how large the packet body is.
- Create helper functions to serizalize/deserialize the Packet and PacketHeader
- Create helpter functions to display the Packet and PacketHeader.